### PR TITLE
ChatGPTのAPIを利用するためのコントローラーファイルを追加

### DIFF
--- a/app/Http/Controllers/ChatGPTController.php
+++ b/app/Http/Controllers/ChatGPTController.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\support\Facades\Http;
+
+class ChatGPTController extends Controller
+{
+    public function showUploadForm()
+    {
+        return view('upload');
+    }
+
+    public function processImage(Request $request)
+    {
+        // 画像のバリデーション
+        $request->validate([
+            'image' => 'required|image|mimes:jpeg,png,jpg|max:2048',
+        ]);
+
+        // 画像を取得
+        $image = $request->file('image');
+        $imagePath = $image->getPathname();
+
+        $base64Image = base64_encode(file_get_contents($imagePath));
+
+    $response = Http::withHeaders([
+        'Authorization' => 'Bearer ' . env('CHATGPT_API_KEY'),
+        'Content-Type' => 'application/json',
+    ])->post('https://api.openai.com/v1/chat/completions', [
+        'model' => 'gpt-4o',
+        'messages' => [
+            [
+                'role' => 'user',
+                'content' => [
+                    ['type' => 'text', 'text' => 'What ingredients are shown in this image? Please output "only" the names of the ingredients in Japanese.'],
+                    ['type' => 'image_url', 'image_url' => ['url' => "data:image/jpeg;base64,{$base64Image}"]]
+                ]
+            ]
+        ],
+        'max_tokens' => 300
+    ]);
+
+    $responseData = $response->json();
+
+    if (isset($responseData['choices'][0]['message']['content'])) {
+        $content = $responseData['choices'][0]['message']['content'];
+        $ingredients = array_filter(explode("\n", trim($content)));
+    } else {
+        \Log::error('API Response Error:', $responseData);
+        $ingredients = ['エラーが発生しました。もう一度お試しください。'];
+    }
+
+    return view('result', ['ingredients' => $ingredients]);
+}
+    
+
+}
+
+

--- a/app/Http/Controllers/ChatGPTController.php
+++ b/app/Http/Controllers/ChatGPTController.php
@@ -3,7 +3,7 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
-use Illuminate\support\Facades\Http;
+use Illuminate\Support\Facades\Http;
 
 class ChatGPTController extends Controller
 {
@@ -25,37 +25,40 @@ class ChatGPTController extends Controller
 
         $base64Image = base64_encode(file_get_contents($imagePath));
 
-    $response = Http::withHeaders([
-        'Authorization' => 'Bearer ' . env('CHATGPT_API_KEY'),
-        'Content-Type' => 'application/json',
-    ])->post('https://api.openai.com/v1/chat/completions', [
-        'model' => 'gpt-4o',
-        'messages' => [
-            [
-                'role' => 'user',
-                'content' => [
-                    ['type' => 'text', 'text' => 'What ingredients are shown in this image? Please output "only" the names of the ingredients in Japanese.'],
-                    ['type' => 'image_url', 'image_url' => ['url' => "data:image/jpeg;base64,{$base64Image}"]]
-                ]
-            ]
-        ],
-        'max_tokens' => 300
-    ]);
+        // ChatGPT APIにリクエストを送信
+        $responseData = $this->sendChatGPTRequest($base64Image);
 
-    $responseData = $response->json();
+        // レスポンスデータを処理
+        if (isset($responseData['choices'][0]['message']['content'])) {
+            $content = $responseData['choices'][0]['message']['content'];
+            $ingredients = array_filter(explode("\n", trim($content)));
+        } else {
+            \Log::error('API Response Error:', $responseData);
+            $ingredients = ['エラーが発生しました。もう一度お試しください。'];
+        }
 
-    if (isset($responseData['choices'][0]['message']['content'])) {
-        $content = $responseData['choices'][0]['message']['content'];
-        $ingredients = array_filter(explode("\n", trim($content)));
-    } else {
-        \Log::error('API Response Error:', $responseData);
-        $ingredients = ['エラーが発生しました。もう一度お試しください。'];
+        return view('result', ['ingredients' => $ingredients]);
     }
 
-    return view('result', ['ingredients' => $ingredients]);
-}
-    
-
+    private function sendChatGPTRequest(string $base64Image)
+    {
+        return Http::withHeaders([
+            'Authorization' => 'Bearer ' . env('CHATGPT_API_KEY'),
+            'Content-Type' => 'application/json',
+        ])->post('https://api.openai.com/v1/chat/completions', [
+            'model' => 'gpt-4o',
+            'messages' => [
+                [
+                    'role' => 'user',
+                    'content' => [
+                        ['type' => 'text', 'text' => 'What ingredients are shown in this image? Please output "only" the names of the ingredients in Japanese.'],
+                        ['type' => 'image_url', 'image_url' => ['url' => "data:image/jpeg;base64,{$base64Image}"]]
+                    ]
+                ]
+            ],
+            'max_tokens' => 300
+        ])->json();
+    }
 }
 
 

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.1",
-        "guzzlehttp/guzzle": "^7.2",
+        "guzzlehttp/guzzle": "^7.7",
         "laravel/framework": "^10.10",
         "laravel/sanctum": "^3.2",
         "laravel/tinker": "^2.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0dbe8bfc541a1ffe13e8b4a6b07240f7",
+    "content-hash": "88e173517c6fb6d1eb05184fcd4cb4e5",
     "packages": [
         {
             "name": "brick/math",
@@ -567,16 +567,16 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.7.0",
+            "version": "7.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "fb7566caccf22d74d1ab270de3551f72a58399f5"
+                "reference": "085b026db54d4b5012f727c80c9958e8b8cbc454"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/fb7566caccf22d74d1ab270de3551f72a58399f5",
-                "reference": "fb7566caccf22d74d1ab270de3551f72a58399f5",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/085b026db54d4b5012f727c80c9958e8b8cbc454",
+                "reference": "085b026db54d4b5012f727c80c9958e8b8cbc454",
                 "shasum": ""
             },
             "require": {
@@ -673,7 +673,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.7.0"
+                "source": "https://github.com/guzzle/guzzle/tree/7.7.1"
             },
             "funding": [
                 {
@@ -689,7 +689,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-05-21T14:04:53+00:00"
+            "time": "2023-08-27T10:02:06+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -8206,5 +8206,5 @@
         "php": "^8.1"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
## 概要
ChatGPTのAPIを利用するためのコントローラーファイルを追加

## 追加・変更点
- 新しいコントローラファイルの追加

## コントローラーの機能説明
- showUploadFormメソッドによって画像を読み込むビュー（upload.blade.php)を表示
- Route::post('/upload', [ChatGptController::class, 'processImage'])->name('upload.process');
- 上記のルーティングによって画像認識を行うprocessImageメソッドが呼ばれる．
- 認識処理終了後に(result.blade.php)を表示


